### PR TITLE
Demonstation of `play` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These are the following Storybook features we attempt to uncover in this project
 | ⏳     | [`loaders`](https://storybook.js.org/docs/writing-stories/loaders) |  |
 | ⏳     | [`decorators`](https://storybook.js.org/docs/writing-stories/decorators) |  |
 | ⏳     | [`render`](https://storybook.js.org/docs/api/csf#custom-render-functions) |  |
-| ⏳     | [`play`](https://storybook.js.org/docs/writing-stories/play-function) |  |
+| ⏳     | [`play`](https://storybook.js.org/docs/writing-stories/play-function) | [PR](https://github.com/storybookjs/svelte-csf-demo/pull/7), [stories](https://main--663faba8e103e55dccd640dc.chromatic.com/?path=/docs/play) |
 | 🟡     | [How to type the meta object and stories](https://storybook.js.org/docs/writing-stories/typescript)   | [PR](https://github.com/storybookjs/svelte-csf-demo/pull/3), [stories](https://main--663faba8e103e55dccd640dc.chromatic.com/?path=/docs/typed) |
 | 🟡     | [JSDoc comments as descriptions](https://storybook.js.org/docs/api/doc-block-description#writing-descriptions) (from component, meta and stories) | [PR](https://github.com/storybookjs/svelte-csf-demo/pull/2), [stories](https://main--663faba8e103e55dccd640dc.chromatic.com/?path=/docs/description-from-comment-svelte-csf--docs) |
 | 🟡     | [Docs](https://storybook.js.org/docs/writing-docs/mdx), including autodocs, MDX docs and `useOf` | [PR](https://github.com/storybookjs/svelte-csf-demo/pull/1), [stories](https://main--663faba8e103e55dccd640dc.chromatic.com/?path=/docs/docs) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ These are the following Storybook features we attempt to uncover in this project
 | ⏳     | [`beforeEach`](https://storybook.js.org/docs/8.1/writing-stories/mocking-modules#using-mocked-modules-in-stories) |  |
 | ⏳     | [`loaders`](https://storybook.js.org/docs/writing-stories/loaders) |  |
 | ⏳     | [`decorators`](https://storybook.js.org/docs/writing-stories/decorators) |  |
-| ⏳     | [`render`](https://storybook.js.org/docs/api/csf#custom-render-functions) |  |
+| ✅     | [`render`](https://storybook.js.org/docs/api/csf#custom-render-functions) |  |
 | ⏳     | [`play`](https://storybook.js.org/docs/writing-stories/play-function) | [PR](https://github.com/storybookjs/svelte-csf-demo/pull/7), [stories](https://main--663faba8e103e55dccd640dc.chromatic.com/?path=/docs/play) |
 | 🟡     | [How to type the meta object and stories](https://storybook.js.org/docs/writing-stories/typescript)   | [PR](https://github.com/storybookjs/svelte-csf-demo/pull/3), [stories](https://main--663faba8e103e55dccd640dc.chromatic.com/?path=/docs/typed) |
 | 🟡     | [JSDoc comments as descriptions](https://storybook.js.org/docs/api/doc-block-description#writing-descriptions) (from component, meta and stories) | [PR](https://github.com/storybookjs/svelte-csf-demo/pull/2), [stories](https://main--663faba8e103e55dccd640dc.chromatic.com/?path=/docs/description-from-comment-svelte-csf--docs) |

--- a/src/docs/PlayComponent.stories.svelte
+++ b/src/docs/PlayComponent.stories.svelte
@@ -1,0 +1,59 @@
+<script context="module">
+	import PlayComponent from './PlayComponent.svelte';
+
+	export const meta = {
+		title: 'Play/Svelte CSF',
+		component: PlayComponent,
+		parameters: {
+			actions: { disable: true },
+			controls: { disable: true },
+		},
+	};
+</script>
+
+<script>
+	import { expect, userEvent, within } from '@storybook/test';
+	import { tick } from 'svelte';
+
+	import { Story } from '@storybook/addon-svelte-csf';
+
+	let i = 0;
+</script>
+
+<Story
+	name="Default"
+	play={async (storyContext) => {
+		const { canvasElement } = storyContext;
+		const canvas = within(canvasElement);
+		const count = await canvas.findByTestId('count');
+
+		await userEvent.click(await canvas.findByText('Increment'));
+		expect(count.textContent).toEqual('1');
+
+		await userEvent.click(await canvas.findByText('Decrement'));
+		expect(count.textContent).toEqual('0');
+	}}
+>
+	<PlayComponent />
+</Story>
+
+<Story
+	name="Custom scope"
+	play={async (storyContext) => {
+		const { canvasElement } = storyContext;
+		const canvas = within(canvasElement);
+		const element = canvas.getByTestId('count');
+
+		expect(element.textContent).toEqual('0');
+
+		i++;
+		await tick();
+		expect(element.textContent).toEqual('1');
+
+		i--;
+		await tick();
+		expect(element.textContent).toEqual('0');
+	}}
+>
+	<p data-testid="count">{i}</p>
+</Story>

--- a/src/docs/PlayComponent.stories.ts
+++ b/src/docs/PlayComponent.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import { expect, userEvent, within } from '@storybook/test';
+
+import PlayComponent from './PlayComponent.svelte';
+
+const meta = {
+	title: 'Play/Regular CSF',
+	component: PlayComponent,
+	parameters: {
+		actions: { disable: true },
+		controls: { disable: true },
+	},
+} satisfies Meta<PlayComponent>;
+
+export default meta;
+
+type Story = StoryObj<PlayComponent>;
+
+export const Default: Story = {
+	play: async (storyContext) => {
+		const { canvasElement } = storyContext;
+		const canvas = within(canvasElement);
+		const count = await canvas.findByTestId('count');
+
+		await userEvent.click(await canvas.findByText('Increment'));
+		expect(count.textContent).toEqual('1');
+
+		await userEvent.click(await canvas.findByText('Decrement'));
+		expect(count.textContent).toEqual('0');
+	},
+};

--- a/src/docs/PlayComponent.svelte
+++ b/src/docs/PlayComponent.svelte
@@ -1,0 +1,14 @@
+<script>
+	$: count = 0;
+</script>
+
+<div>
+	<h1>Counter</h1>
+	<p>
+		You clicked
+		<code data-testid="count">{count}</code>
+		times
+	</p>
+	<button type="button" on:click={() => count--}>Decrement</button>
+	<button type="button" on:click={() => count++}>Increment</button>
+</div>


### PR DESCRIPTION
## Notes

1. I am not sure. It seems like Svelte CSF format has an advantage with possiblity of creating a custom
capturing scope over the regular CSF format. I couldn't recreate this example with success - even with using `render` function.
